### PR TITLE
Fix destination keys being unmountable on Windows

### DIFF
--- a/usbsas-files2fs/src/lib.rs
+++ b/usbsas-files2fs/src/lib.rs
@@ -228,7 +228,10 @@ impl WaitNewFileState {
         let newstate = match comm.recv_req()? {
             Msg::NewFile(msg) => self.newfile(comm, msg.path, msg.timestamp, msg.ftype)?,
             Msg::Close(_) => {
-                let bitvec = self.fs.unmount_fs()?.into_inner().get_bitvec()?;
+                let mut bitvec = self.fs.unmount_fs()?.into_inner().get_bitvec()?;
+                // Ensure old MBR / GPT is erased
+                let total_sectors = bitvec.len();
+                bitvec[..(SECTOR_START as usize).min(total_sectors)].fill(true);
                 comm.close(proto::writedst::ResponseClose {})?;
                 State::ForwardBitVec(ForwardBitVecState { bitvec })
             }


### PR DESCRIPTION
## Problem

A destination device that was previously formatted with GPT can't be mounted on
windows after a transfer. The disk manager shows a healthy partition with the
right filesystem, but no drive letter is assigned and assigning one manually
fails with "the specified file could not be found". The same device mounts fine
on linux and the copied files are intact. Reproduced with FAT32, exFAT and NTFS
on several windows machines, which pointed at something below the filesystem.

## Cause

fs2dev only writes the sectors marked in the bit vector built by files2fs, so
the sectors the new filesystem doesn't cover keep the destination's former
content. The previous GPT header (LBA 1) and entry array (LBA 2-33) survive the
transfer and windows rejects the device. Zeroing the device beforehand
(`wipefs -a` then `dd if=/dev/zero`) makes it mount, which confirms it.

## Fix

Mark the sectors preceding the partition in the bit vector so fs2dev rewrites
them with zeros. `fill()` only schedules sectors that were skipped — their
content in the sparse file is zero — it never alters an already written sector
such as the MBR.

Two unrelated changes from the first version of this PR (non-zero MBR disk
signature, 1 MiB partition alignment) have been dropped and will be proposed as
separate issues.